### PR TITLE
Update MenusTableSeeder.php

### DIFF
--- a/database/seeds/MenusTableSeeder.php
+++ b/database/seeds/MenusTableSeeder.php
@@ -59,7 +59,7 @@ class MenusTableSeeder extends Seeder
 				'icon' => 'fa-line-chart',
 			],
 			[
-				'slug' => 'membership',
+				'slug' => 'memberships',
 				'parent_slug' => 'reports',
 				'permission_id' => 11,
 				'menu_group' => 'main',


### PR DESCRIPTION
slug for membership report should be unique

This fixes a bug where one cannot change the path of the Membership/Members menu branch without the menu option being given to the reports parent_slug.

Code to walk the hierarchy is needed if the same child menu name is given to two separate parents.